### PR TITLE
include port (updates #2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function (url, location, protocolMap, defaultProtocol) {
       protocol: proto,
       slashes: true,
       hostname: url.hostname,
+      port: url.port,
       pathname: url.pathname,
       search: url.search
     })


### PR DESCRIPTION
In [this](https://github.com/dominictarr/relative-url/commit/6ea2734c74cbe7bbb5b7840dcd0a5dbe7430a24f#diff-168726dbe96b3ce427e7fedce31bb0bcR45) case the port is only included in `url.host` not `url.hostname`, so also pass `port: url.port` to `URL.format()`.
